### PR TITLE
[docker-compose] add volume mount for session persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine3.19
 WORKDIR /app
-RUN corepack enable && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/locatime
-COPY . .
-RUN yarn
-
+RUN corepack enable && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
+COPY package.json yarn.lock* tsconfig.json ./
+RUN yarn --frozen-lockfile --production
+COPY src ./src
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ RUN corepack enable && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 COPY package.json yarn.lock* tsconfig.json ./
 RUN yarn --frozen-lockfile --production
 COPY src ./src
+VOLUME /app/db
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ github:（actions方式正常可用）
 ### 拉取代码
 目前没有提供打包好的镜像，需要拉取下来自行打包使用
 ```shell
-git clone https://gitlab.com/gooin/dailysync.git
+git clone https://github.com/gooin/dailysync-rev.git
 ```
 ### 修改配置文件
 打开`.env`文件，按注释填入信息

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: Dockerfile
     env_file:
       - .env
+    volumes:
+      - ./db:/app/db
     container_name: daily-sync
     command: yarn sync_cn
     logging:


### PR DESCRIPTION
## Summary
- Mount `./db:/app/db` in docker-compose to persist SQLite session data across container recreates
- Update Dockerfile to only copy necessary files (`package.json`, `yarn.lock`, `tsconfig.json`, `src/`)
- Use `--production` flag to skip devDependencies
- Add `VOLUME /app/db` to Dockerfile for explicit data persistence
- Exclude `.env` and `db/` from image to prevent sensitive credentials from being baked into the container image
- Fix README clone URL to use GitHub instead of GitLab

## Changes

### docker-compose.yml
Adds volume mount `./db:/app/db` to persist the SQLite database containing saved Garmin login sessions.

**Before:** No volumes configured. Recreating the container (`docker-compose down && up`) would lose all saved Garmin login sessions, requiring re-authentication every time.

**After:** Sessions persist across container lifecycle.

### Dockerfile
Optimizes image build and improves security:

- **Before:** `COPY . .` - copied everything (including `.env`, `db/`, `node_modules`, `.git`) into image
- **After:** Only copies necessary files - `package.json`, `yarn.lock`, `tsconfig.json`, and `src/` directory
- Uses `--production` flag to skip devDependencies (smaller image size)
- Added `VOLUME /app/db` to ensure data persists even when running `docker run` without `-v`
- `.env` and `db/` are never baked into the image, so credentials remain safe even if the image is pushed to a public registry

### README.md
Fixes the clone URL from GitLab to GitHub since this repo is hosted on GitHub.

## Motivation
Encountered 429 rate limit and had to switch IPs, but found that login sessions were not persisted across container recreates. This change ensures sessions persist, avoiding re-authentication after IP changes.

## Testing
Verified that after container recreation:
- `GarminGlobal: login by saved session` - confirms session is reused
- `GarminCN: login by saved session` - confirms session is reused
- No re-authentication required