### PR TITLE
fix: remove --production flag to include ts-node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine3.19
 WORKDIR /app
 RUN corepack enable && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 COPY package.json yarn.lock* tsconfig.json ./
-RUN yarn --frozen-lockfile --production
+RUN yarn --frozen-lockfile
 COPY src ./src
 VOLUME /app/db
 CMD ["bash"]


### PR DESCRIPTION
`ts-node` is a devDependency required by the npm scripts (e.g., `sync_global`, `migrate_garmin_global_to_cn`). Using `--production` flag skips devDependencies, causing these scripts to fail.